### PR TITLE
Ensure compatibility with PHPStan version 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
 before_script:
   - composer self-update
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "finwe@finwe.info"
         }
     ],
-    
+
     "extra": {
         "phpstan": {
             "includes": [
@@ -25,17 +25,16 @@
     },
 
     "require": {
-        "php": "~7.1",
-        "phpstan/phpstan": "^0.12",
-        "fzaninotto/faker": "^1.6.0"
+        "php": "^7.1 || ^8",
+        "phpstan/phpstan": "^1",
+        "fzaninotto/faker": "^1.6"
     },
 
     "require-dev": {
-        "slevomat/coding-standard": "^3.0.3",
-        "phing/phing": "^2.16.0",
+        "phing/phing": "^2.16",
         "phpunit/phpunit": "^5.7",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "consistence/coding-standard": "^2.0"
+        "consistence/coding-standard": "^3"
     }
 
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,4 @@
 parameters:
-	level: 4
-	ignoreErrors: []
+    level: 4
+    paths:
+    - src


### PR DESCRIPTION
Hi @finwe 👋 

Thanks for this package. I tried to get it up and running with PHPStan 1 and PHP 8.1, so I updated a bunch of dependencies and fixed the errors I could.

PHPCS is failing with a couple hundred errors, most of which should be fixable automatically. I did not want to blow up the size of this PR, perhaps you can check it out and commit the code style fixes? Feel free to push to my branch or use the changes I made in your own branch.